### PR TITLE
Fix license

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -12,10 +12,12 @@ jobs:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables: {}
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @janjagusch
+* @fhoehle @janjagusch

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,11 +23,13 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -104,7 +106,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}

--- a/README.md
+++ b/README.md
@@ -183,5 +183,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@fhoehle](https://github.com/fhoehle/)
 * [@janjagusch](https://github.com/janjagusch/)
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "grype-feedstock"
-version = "3.59.1"  # conda-smithy version used to generate this file
+version = "3.61.1"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/grype-feedstock"
 authors = ["@conda-forge/grype"]
 channels = ["conda-forge"]

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,8 @@ go-licenses save . \
     --ignore github.com/xi2/xz \
     --ignore github.com/deitch/magic/pkg/magic \
     --ignore github.com/deitch/magic/pkg/magic/internal \
-    --ignore github.com/deitch/magic/pkg/magic/parser
+    --ignore github.com/deitch/magic/pkg/magic/parser \
+    --ignore github.com/in-toto/attestation
 
 go build \
     -v \

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -20,6 +20,9 @@ source:
   - url: https://raw.githubusercontent.com/deitch/magic/2def47b612f6f806d1e136bbec1c34fdefacf04a/LICENSE
     sha256: 2423c6eb9948e617a61f7a2d1cb463c69d60e599fbae5931551631d2a8730838
     file_name: LICENSE-magic
+  - url: https://raw.githubusercontent.com/in-toto/attestation/refs/tags/v1.2.0/LICENSE
+    sha256: b3a6ac899861c2c28a1abd5c7ea8733fefaed6938d730e099c42671386032aeb
+    file_name: LICENSE-attestation
 
 build:
   number: 0
@@ -42,9 +45,11 @@ about:
     - library_licenses/
     - LICENSE-xz
     - LICENSE-mathutil
+    - LICENSE-attestation
   summary: A vulnerability scanner for container images and filesystems
   homepage: https://github.com/anchore/grype
 
 extra:
   recipe-maintainers:
     - janjagusch
+    - fhoehle

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: grype
-  version: "0.111.0"
+  version: "0.111.1"
 
 package:
   name: ${{ name|lower }}
@@ -10,7 +10,7 @@ package:
 
 source:
   - url: https://github.com/anchore/grype/archive/refs/tags/v${{ version }}.tar.gz
-    sha256: 01d60c3e785f635da8f060712df2a901025386b740eb173e365ae0c263e66792
+    sha256: f7d8ff24a729c489cb1356ef539251945679a73c9de704dd6871a2455229c44d
   - url: https://gitlab.com/cznic/mathutil/-/raw/b13e5b5643328f15fd2fcedc85f647f0d8f9180f/LICENSE  # v1.5.0
     sha256: bfa9bf72a72ca009fd62a8f84fca3dca67e51d93af96352723646599898b6cf5
     file_name: LICENSE-mathutil


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
The `openvex/go-vex` modules requires the `in-toto/attestation` which is missing a standardized license.

```
go mod graph | grep in-toto
# github.com/anchore/grype                  github.com/in-toto/attestation@v1.2.0
# github.com/openvex/go-vex@v0.2.8          github.com/in-toto/attestation@v1.2.0
...
```